### PR TITLE
Fixed compatibility with iOS under Capacitor

### DIFF
--- a/src/ios/CordovaBambuserBroadcaster.m
+++ b/src/ios/CordovaBambuserBroadcaster.m
@@ -43,6 +43,7 @@
     [bambuserView setOrientation: [UIApplication sharedApplication].statusBarOrientation];
     [self.webView.superview insertSubview: bambuserView.view belowSubview:self.webView];
     [bambuserView setPreviewFrame: CGRectMake(0, 0, self.webView.bounds.size.width, self.webView.bounds.size.height)];
+    [self.viewController.view sendSubviewToBack:bambuserView.view];
     [self.commandDelegate sendPluginResult: [CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId: command.callbackId];
 }
 


### PR DESCRIPTION
When using this plugin under Capacitor (V3 RC in this case), in iOS the web view is behind the camera view.

Adding this single line to re-order the views correctly means things now work as expected under Capacitor 3.