### PR TITLE
fix(build): use unzip stream

### DIFF
--- a/bin/install-sdk.js
+++ b/bin/install-sdk.js
@@ -1,7 +1,7 @@
 var https = require('https');
 var request = require('request');
 var path = require('path');
-var unzipper = require('unzipper');
+const unzip = require('unzip-stream');
 
 var sdks = {
   android: {
@@ -25,4 +25,4 @@ if (!sdk) {
 request = require('request');
 
 var stream = request({url: sdk.url, pool: new https.Agent({keepAlive: false})});
-stream.pipe(unzipper.Extract({path: path.join(__dirname, '..')}));
+stream.pipe(unzip.Extract({path: path.join(__dirname, '..')}));

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   },
   "dependencies": {
     "request": "^2.88.0",
-    "unzipper": "^0.9.3"
+    "unzip-stream": "^0.3.1"
   }
 }


### PR DESCRIPTION
Use unzip-stream instead of  unzipper to avoid an issue where download file is corrupted in latest node version. 
Linked issue - https://github.com/ZJONSSON/node-unzipper/issues/271